### PR TITLE
Fix for Issue #9 "Failure when using .NET 4.6 or higher"

### DIFF
--- a/AspNetCore.Authentication.WsFederation/AspNetCore.Authentication.WsFederation.csproj
+++ b/AspNetCore.Authentication.WsFederation/AspNetCore.Authentication.WsFederation.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="1.1.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocol.Extensions" Version="1.0.4.403061554" />
+    <PackageReference Include="System.Net.Http" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net47</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fix for #9 
The Bug was solved in System.Net.Http, see [#6 Inheritance security rules violated by type: 'System.Net.Http.WebRequestHandler'. Derived types must either match the security accessibility of the base type or be less accessible.](https://github.com/dotnet/announcements/issues/6) for more details.

I've targeted .NET 4.7 in the Sample project and added a dependency to the System.Net.Http package in the Middleware project.

Workaround: Adding the dependency to System.Net.Http in the consuming Web App (e.g. the Sample project) works as well.